### PR TITLE
fix: ability to process package-lock.json with more than 1024*1024 bytes

### DIFF
--- a/index.js
+++ b/index.js
@@ -200,6 +200,12 @@ function merge (argv) {
       maxBuffer: Infinity
     }
   )
+
+  if (ret.error) {
+    console.error('npm-merge-driver: "git merge-file" fails with:', ret.error)
+    throw ret.error
+  }
+
   fs.writeFileSync(argv['%P'], ret.stdout)
   try {
     cp.execSync(argv.command, {

--- a/index.js
+++ b/index.js
@@ -196,7 +196,8 @@ function merge (argv) {
     'git',
     ['merge-file', '-p', argv['%A'], argv['%O'], argv['%B']],
     {
-      stdio: [0, 'pipe', 2]
+      stdio: [0, 'pipe', 2],
+      maxBuffer: Infinity
     }
   )
   fs.writeFileSync(argv['%P'], ret.stdout)


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

#### Problem
In the case when you have package-lock.json is more than 1048576 (1024 * 1024) bytes child process fails with error here - https://github.com/npm/npm-merge-driver/blob/latest/index.js#L195-L201. Error:
```
Error: spawnSync git ENOBUFS
    at Object.spawnSync (internal/child_process.js:1041:20)
    at Object.spawnSync (child_process.js:616:24)
    at Object.merge [as handler] (/Users/dudkevich/job/projects/third-party/npm-merge-driver/index.js:206:18)
    at Object.runCommand (/Users/dudkevich/job/projects/third-party/npm-merge-driver/node_modules/yargs/lib/command.js:228:22)
    at Object.parseArgs [as _parseArgs] (/Users/dudkevich/job/projects/third-party/npm-merge-driver/node_modules/yargs/yargs.js:1013:30)
    at Object.get [as argv] (/Users/dudkevich/job/projects/third-party/npm-merge-driver/node_modules/yargs/yargs.js:957:21)
    at parseArgs (/Users/dudkevich/job/projects/third-party/npm-merge-driver/index.js:93:21)
    at Object.<anonymous> (/Users/dudkevich/job/projects/third-party/npm-merge-driver/index.js:11:3)
    at Module._compile (internal/modules/cjs/loader.js:1138:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1158:10) {
  errno: 'ENOBUFS',
  code: 'ENOBUFS',
  syscall: 'spawnSync git',
  path: 'git',
  spawnargs: [
    'merge-file',
    '-p',
    '.merge_file_D1OBa2',
    '.merge_file_dX2qR6',
    '.merge_file_I14Rra'
  ]
}
```

To fix it I increase `maxBuffer` to `Infinity` and add error handler for child process in order to exit if something goes wrong.

#### Environment:
**node**: 12.18.0
**npm**: 6.14.5
**git**: 2.29.1
